### PR TITLE
[docs] update course name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ML in Production Practice
+# AI engineering interactive course - work in progress - stay tuned!
 
-This repository contains practical exercises and reference implementations for the [ML in Production](https://edu.kyrylai.com/courses/ml-in-production) course.
+This repository contains practical exercises and reference implementations for the AI engineering interactive course. Work in progress - stay tuned!
 
 ![Course banner](./docs/into.jpg)
 


### PR DESCRIPTION
## Summary
- rename course in README

## Testing
- `ruff format`
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_6841160336bc8328bfec0d4bb30015e4